### PR TITLE
Allow internal decimals.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,20 +16,24 @@
 ///
 /// A hostname is valid if the following condition are true:
 ///
-/// - It does not start or end with `-`.
-/// - It does not contain any characters outside of the alphanumeric range, except for `-`.
+/// - It does not start or end with `-` or `.`.
+/// - It does not contain any characters outside of the alphanumeric range, except for `-` and `.`.
 /// - It is not empty.
 pub fn is_valid(hostname: &str) -> bool {
-    fn is_alphanumeric(byte: u8) -> bool {
-        (byte >= b'a' && byte <= b'z') || (byte >= b'A' && byte <= b'Z')
-            || (byte >= b'0' && byte <= b'9') || byte == b'-'
+    fn is_valid_char(byte: u8) -> bool {
+        (byte >= b'a' && byte <= b'z')
+            || (byte >= b'A' && byte <= b'Z')
+            || (byte >= b'0' && byte <= b'9')
+            || byte == b'-'
+            || byte == b'.'
     }
 
-    !(hostname.bytes().any(|byte| !is_alphanumeric(byte))
+    !(hostname.bytes().any(|byte| !is_valid_char(byte))
         || hostname.ends_with('-')
         || hostname.starts_with('-')
-        || hostname.is_empty()
-    )
+        || hostname.ends_with('.')
+        || hostname.starts_with('.')
+        || hostname.is_empty())
 }
 
 #[cfg(test)]
@@ -38,7 +42,14 @@ mod tests {
 
     #[test]
     fn valid_hostnames() {
-        for hostname in &["VaLiD-HoStNaMe", "50-name", "235235"] {
+        for hostname in &[
+            "VaLiD-HoStNaMe",
+            "50-name",
+            "235235",
+            "example.com",
+            "VaLid.HoStNaMe",
+            "123.456",
+        ] {
             assert!(is_valid(hostname), "{} is not valid", hostname);
         }
     }
@@ -51,6 +62,8 @@ mod tests {
             "asdf@fasd",
             "@asdfl",
             "asd f@",
+            ".invalid",
+            "invalid.name.",
         ] {
             assert!(!is_valid(hostname), "{} should not be valid", hostname);
         }


### PR DESCRIPTION
According to [RFC 952](https://datatracker.ietf.org/doc/html/rfc952) referenced by [RFC 1132 in section 2.1](https://datatracker.ietf.org/doc/html/rfc1123#page-13) internal decimals are allowed.
```
A "name" (Net, Host, Gateway, or Domain name) is a text string up
   to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus
   sign (-), and period (.).  Note that periods are only allowed when
   they serve to delimit components of "domain style names".
```